### PR TITLE
Fixes for problem with bash word splitting parameters of no value in double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.1
+
+Fixes for empty variables https://github.com/MartyEwings/agent_run_with_tags/issues/2)
+Formatting
+
 ## Release 1.0.0
 
 Updated to PDK 1.10.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 
 # agent_run_with_tags
 
-
-#### Table of Contents
+## Table of Contents
 
 1. [Description](#description)
 2. [Setup - The basics of getting started with agent_run_with_tags](#setup)
@@ -16,12 +15,11 @@
 
 ## Description
 
-The Task in this module fills a hole in orchestrators native abilities. It allows you to run puppet agent with the --tags options on linux nodes running a bash shell.
+The Task in this module fills a hole in orchestrators native abilities. It allows you to run puppet agent with the `--tags` options on linux nodes running a bash shell.
 
-By default it requires just one tag to be passed as an option, it allows up to 2. there are also 2 additional optional parameters param1 and param2 which can be used to pass standard puppet agent flags, such as --noop or --debug
+By default it requires a comma separated list of tags (no spaces). There are also 2 additional optional parameters param1 and param2 which can be used to pass standard puppet agent flags, such as `--noop` or `--debug`
 
 ## Setup
-
 
 ### Beginning with agent_run_with_tags  
 
@@ -29,21 +27,16 @@ Install the module, the tasks will be populated in the tasks dropdown in the PE 
 
 ## Usage
 
-This task can be run against any linux node with a bash shell, it has 4 parameters:
+This task can be run against any linux node with a bash shell, it takes up to 3 parameters:
 
-tag1 - mandatory the tag you want to run the agent run with
-tag2 - an optional second tag
-param1 - an optional param that can be used to pass any agent flag, valid options include --debug --noop --fingerprint
-param2 - a second optional parameter incase one is not enough
-
-
+* `tags` (mandatory) - a comma separated list of tags (no spaces)
+* `param1` (optional) parameter that can be used to pass any agent flag, valid options include `--debug --noop --fingerprint`
+* `param2` (optional) a second parameter incase one is not enough
 
 ## Reference
 
 ## Limitations
 
-restricted to use on linux platforms with a bash shell
+Restricted to use on linux platforms with a bash shell
 
 ## Development
-
-

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "martyewings-agent_run_with_tags",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "martyewings",
   "summary": "Allows remote running of puppet agents with up to two --tags",
   "license": "Apache-2.0",

--- a/tasks/agent_run_tags.json
+++ b/tasks/agent_run_tags.json
@@ -1,23 +1,19 @@
 {
   "puppet_task_version": 1,
   "supports_noop": false,
-  "description": "passes up to 2 tags to a puppet agent run, and allows for 2 addtional parameters eg --debug --nooop --no-noop",
+  "description": "passes a comma separated list of tags (no spaces) to a puppet agent run, and allows for 2 addtional parameters eg --debug --noop --no-noop",
   "parameters": {
-  "tag1": {
-         "description": "first tag, mandatory",
-         "type": "String[1]"
-},
-  "tag2": {
-         "description": "second tag, optional",
-         "type": "Optional[String[1]]"
-} , 
-  "param1": {
-         "description": "optional additional parameter eg --debug",
-         "type": "Optional[String[1]]"
-},
-  "param2": {
-         "description": "optional additional parameter eg --noop",
-         "type": "Optional[String[1]]"
-}
-}
+    "tags": {
+      "description": "comma separated list of tags (no spaces), mandatory",
+      "type": "String[1]"
+    },
+    "param1": {
+      "description": "optional additional parameter eg --noop",
+      "type": "Optional[String[1]]"
+    },
+    "param2": {
+      "description": "optional additional parameter eg --debug",
+      "type": "Optional[String[1]]"
+    }
+  }
 }

--- a/tasks/agent_run_tags.sh
+++ b/tasks/agent_run_tags.sh
@@ -2,4 +2,5 @@
 
 # Puppet Task Name: agent_run_tags
 #
-puppet agent -t "$PT_param1" "$PT_param2"  --tags "$PT_tag1" "$PT_tag2"
+declare -a PT_params=(${PT_param1} ${PT_param2})
+puppet agent -t "${PT_params[@]}" --tags "${PT_tags}"


### PR DESCRIPTION
Fixes for issue #2 